### PR TITLE
zephyr: drop usb.loopback from blacklist

### DIFF
--- a/zephyr.yml
+++ b/zephyr.yml
@@ -28,7 +28,7 @@ triggers:
           BROKE_TESTS: |
             samples/basic
             samples/subsys/nvs
-            samples/subsys/usb/testusb/usb.loopback
+            samples/subsys/usb/testusb
             tests/kernel/interrupt
         script-repo:
           name: gavel-ci-projects


### PR DESCRIPTION
Originally, I thought this would blacklist the test case, but it turns
out it doesn't. testusb is the case we should be blacklisting.

Signed-off-by: Tyler Baker <tyler@foundries.io>